### PR TITLE
Add link to Drivers & Clients

### DIFF
--- a/self-hosted-deployment/manual-deployment/cli-and-drivers.mdx
+++ b/self-hosted-deployment/manual-deployment/cli-and-drivers.mdx
@@ -1,8 +1,8 @@
 ---
-title: CLI and Drivers
+title: "CLI and Drivers"
 ---
 
-In order to access the Regatta database, one must install Regatta Connect which includes the 
+In order to access the Regatta database, one must install Regatta Connect which includes the
 Regatta CLI and the various drivers supported.
 
-For further details, please refer to the Regatta – **On Prem Getting Started Guide.**
+For further details, please refer to the Regatta – [**Drivers & Clients**](https://docs.regatta.dev/drivers-and-clients/connecting-applications-to-regatta)**.**


### PR DESCRIPTION
Originally the Self Hosted deployment would refer to a different document, here we replace that with a link to the document in the Doc Hub