### PR TITLE
Update supported date & timestamp range

### DIFF
--- a/sql/data-types/date-time-types.mdx
+++ b/sql/data-types/date-time-types.mdx
@@ -5,8 +5,8 @@ title: "Date/Time types"
 | Data type         | Size    | Ranges                             | Resolution                       | Description   |
 | :---------------- | :------ | :--------------------------------- | :------------------------------- | :------------ |
 | `TIME [(p)]`      | 8 bytes | 00:00:00.000000 to 24:00:00.000000 | Between seconds and microseconds | Time of day   |
-| `DATE`            | 8 bytes | 4713 BC to 5874897 AD              | days                             | Date          |
-| `TIMESTAMP [(p)]` | 8 bytes | 4713 BC to 294276 AD               | Between seconds and microseconds | Date and time |
+| `DATE`            | 8 bytes | 294240 BC to 294240 AD             | days                             | Date          |
+| `TIMESTAMP [(p)]` | 8 bytes | 294240 BC to 294240 AD             | Between seconds and microseconds | Date and time |
 
 `p` is an optional precision value to specify the number of fractional digits retained in the seconds field. Range of `p` is from 0 to 6. Default is 6.
 

--- a/sql/dql/explain.mdx
+++ b/sql/dql/explain.mdx
@@ -7,11 +7,7 @@ The command returns the execution plan of a statement, without actually executin
 ## Synopsis
 
 ```
-EXPLAIN [ (option [, ... ]) ] statement
-
-where option is one of:
-  VERBOSE [ {TRUE | FALSE} ]
-  COSTS [ {TRUE | FALSE} ]
+EXPLAIN statement
 ```
 
 ## Description


### PR DESCRIPTION
Updated the spec to match the current implementation. The original spec copied the postgres limits, but our implementation is different and creates different limits.

I also removed EXPLAIN parameters that are meant for internal use and shouldn't be part of the external spec.