### PR TITLE
Update support contact to email address

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -15,10 +15,8 @@
         "icon": "house",
         "groups": [
           {
-            "group": " ",
-            "pages": [
-              "home"
-            ]
+            "group": "Home",
+            "pages": ["home", "support"]
           }
         ]
       },
@@ -76,9 +74,7 @@
         "groups": [
           {
             "group": "SQL Specification",
-            "pages": [
-              "/sql/introduction"
-            ]
+            "pages": ["sql/introduction"]
           },
           {
             "group": "Data Types",
@@ -106,9 +102,7 @@
           },
           {
             "group": "SQL Syntax Conventions",
-            "pages": [
-              "sql/sql-syntax-convention"
-            ]
+            "pages": ["sql/sql-syntax-convention"]
           },
           {
             "group": "Data Definition Language (DDL) Commands",
@@ -135,10 +129,7 @@
           },
           {
             "group": "Data Query Language",
-            "pages": [
-              "sql/dql/select",
-              "sql/dql/explain"
-            ]
+            "pages": ["sql/dql/select", "sql/dql/explain"]
           },
           {
             "group": "Hints",
@@ -310,9 +301,7 @@
         "groups": [
           {
             "group": "Self-Hosted Deployment",
-            "pages": [
-              "self-hosted-deployment/prerequisites"
-            ]
+            "pages": ["self-hosted-deployment/prerequisites"]
           },
           {
             "group": "Regatta Deployment Tool",
@@ -417,7 +406,7 @@
     "links": [
       {
         "label": "Support",
-        "href": "mailto:support@regatta.dev"
+        "href": "/support"
       }
     ],
     "primary": {

--- a/docs.json
+++ b/docs.json
@@ -16,7 +16,10 @@
         "groups": [
           {
             "group": "Home",
-            "pages": ["home", "support"]
+            "pages": [
+              "home",
+              "support"
+            ]
           }
         ]
       },
@@ -74,7 +77,9 @@
         "groups": [
           {
             "group": "SQL Specification",
-            "pages": ["sql/introduction"]
+            "pages": [
+              "sql/introduction"
+            ]
           },
           {
             "group": "Data Types",
@@ -102,7 +107,9 @@
           },
           {
             "group": "SQL Syntax Conventions",
-            "pages": ["sql/sql-syntax-convention"]
+            "pages": [
+              "sql/sql-syntax-convention"
+            ]
           },
           {
             "group": "Data Definition Language (DDL) Commands",
@@ -129,7 +136,10 @@
           },
           {
             "group": "Data Query Language",
-            "pages": ["sql/dql/select", "sql/dql/explain"]
+            "pages": [
+              "sql/dql/select",
+              "sql/dql/explain"
+            ]
           },
           {
             "group": "Hints",
@@ -301,7 +311,9 @@
         "groups": [
           {
             "group": "Self-Hosted Deployment",
-            "pages": ["self-hosted-deployment/prerequisites"]
+            "pages": [
+              "self-hosted-deployment/prerequisites"
+            ]
           },
           {
             "group": "Regatta Deployment Tool",

--- a/docs.json
+++ b/docs.json
@@ -417,7 +417,7 @@
     "links": [
       {
         "label": "Support",
-        "href": "https://rdbproject.atlassian.net/servicedesk/customer/portals"
+        "href": "mailto:support@regatta.dev"
       }
     ],
     "primary": {

--- a/support.mdx
+++ b/support.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Contact Support"
+hidden: true
 ---
 
 Access the support portal, or contact us at [support@regatta.dev](mailto:support@regatta.dev) to request access.
@@ -15,7 +16,7 @@ Access the support portal, or contact us at [support@regatta.dev](mailto:support
 
 <Columns cols={2}>
   <Column>
-    Copy Support Email:
+    Support Email:
 
     ```text
     support@regatta.dev

--- a/support.mdx
+++ b/support.mdx
@@ -1,8 +1,8 @@
 ---
-title: "Support"
+title: "Contact Support"
 ---
 
 We are here to help!
 
-- **Email us directly:** [support@regatta.dev](mailto:support@regatta.dev) (Click to open your mail app)
-- **Copy email:** `support@regatta.dev`
+**Open Support Portal:** [support@regatta.dev](mailto:support@regatta.dev) (Click to open your mail app)
+**Copy email:** `support@regatta.dev`

--- a/support.mdx
+++ b/support.mdx
@@ -2,7 +2,25 @@
 title: "Contact Support"
 ---
 
-We are here to help!
+Access the support portal, or contact us at [support@regatta.dev](mailto:support@regatta.dev) to request access.
 
-**Open Support Portal:** [support@regatta.dev](mailto:support@regatta.dev) (Click to open your mail app)
-**Copy email:** `support@regatta.dev`
+<Columns>
+  <Column>
+    <Card title="Open Support Portal" icon="sparkles" href="https://regattadata.atlassian.net/servicedesk/customer/portal/1">
+    </Card>
+  </Column>
+  <Column>
+  </Column>
+</Columns>
+
+<Columns cols={2}>
+  <Column>
+    Copy Support Email:
+
+    ```text
+    support@regatta.dev
+    ```
+  </Column>
+  <Column>
+  </Column>
+</Columns>

--- a/support.mdx
+++ b/support.mdx
@@ -1,0 +1,8 @@
+---
+title: "Support"
+---
+
+We are here to help!
+
+- **Email us directly:** [support@regatta.dev](mailto:support@regatta.dev) (Click to open your mail app)
+- **Copy email:** `support@regatta.dev`


### PR DESCRIPTION
## Summary
This change updates the support contact link from a Jira Service Desk portal to a direct email address.

## Changes
- Updated the support contact link in `docs.json` to `mailto:support@regatta.dev`.

<!-- mintlify-editor-comments:start -->
Mintlify
---
0 threads from 0 users in Mintlify

- No unresolved comments
<!-- mintlify-editor-comments:end -->

<!-- mintlify-comment-->

<a href="https://dashboard.mintlify.com/regatta/regatta/editor/topaz%2Fsupport-link?source=pr_comment" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://d3gk2c5xim1je2.cloudfront.net/assets/open-mintlify-editor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://d3gk2c5xim1je2.cloudfront.net/assets/open-mintlify-editor-light.svg"><img src="https://d3gk2c5xim1je2.cloudfront.net/assets/open-mintlify-editor-light.svg" alt="Open in Mintlify Editor"></picture></a>

<!-- /mintlify-comment -->